### PR TITLE
Adds 'turn', 'error', 'teampreview', 'poke', and 'clearpoke' cases for battle actions

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -285,6 +285,8 @@ class PokeClient extends EventEmitter2
       when MESSAGE_TYPES.BATTLE.TIE
         return {type}
 
+      when MESSAGE_TYPES.BATTLE.ACTIONS.MAJOR.TURN
+        return {type, data: data}
       when MESSAGE_TYPES.BATTLE.ACTIONS.MAJOR.MOVE
         [pokemon, move, target] = data.split '|'
         return {type, data: {pokemon, move, target}}

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -267,11 +267,12 @@ class PokeClient extends EventEmitter2
         [name, description] = data.split ': '
         return {type, data: {name, description}}
       when MESSAGE_TYPES.BATTLE.CLEARPOKE
-        null
+        return {type}
       when MESSAGE_TYPES.BATTLE.POKE
-        null
+        [player, poke, item] = data.split '|'
+        return {type, player: player, poke: poke, item: item != ''}
       when MESSAGE_TYPES.BATTLE.TEAMPREVIEW
-        null
+        return {type}
       when MESSAGE_TYPES.BATTLE.REQUEST
         return {type, data: JSON.parse data}
       when MESSAGE_TYPES.BATTLE.INACTIVE

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -284,6 +284,10 @@ class PokeClient extends EventEmitter2
         return {type, data}
       when MESSAGE_TYPES.BATTLE.TIE
         return {type}
+      when MESSAGE_TYPES.BATTLE.ERROR
+        [error, description] = data.split '] '
+        error = error.replace /\[/, ''
+        return {type, data: {error, description}}
 
       when MESSAGE_TYPES.BATTLE.ACTIONS.MAJOR.TURN
         return {type, data: data}

--- a/src/symbols.coffee
+++ b/src/symbols.coffee
@@ -44,6 +44,7 @@ MESSAGE_TYPES =
 
     ACTIONS:
       MAJOR:
+        TURN: Symbol.for 'psc:token:turn'
         MOVE: Symbol.for 'psc:token:move'
         SWITCH: Symbol.for 'psc:token:switch'
         DRAG: Symbol.for 'psc:token:drag'

--- a/src/symbols.coffee
+++ b/src/symbols.coffee
@@ -41,6 +41,7 @@ MESSAGE_TYPES =
     START: Symbol.for 'psc:token:start'
     WIN: Symbol.for 'psc:token:win'
     TIE: Symbol.for 'psc:token:tie'
+    ERROR: Symbol.for 'psc:token:error'
 
     ACTIONS:
       MAJOR:


### PR DESCRIPTION
I need to be able to parse turns during battles directly, so I added the simple case for major battle actions